### PR TITLE
feat: add auth project configuration and update logging in reservatio…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/apps/auth/Dockerfile
+++ b/apps/auth/Dockerfile
@@ -1,0 +1,34 @@
+FROM node:alpine AS development
+
+WORKDIR /src/app
+
+COPY package.json ./
+COPY pnpm-lock.yaml ./
+
+RUN npm i -g @nestjs/cli
+
+RUN npm install -g pnpm
+
+RUN pnpm install
+
+COPY . .
+
+RUN pnpm run build
+
+FROM node:alpine AS production
+
+ARG NODE_ENV=production
+ENV NODE_ENV=${NODE_ENV}
+
+WORKDIR /src/app
+
+COPY package.json ./
+COPY pnpm-lock.yaml ./
+
+RUN npm install -g pnpm
+
+RUN pnpm install --prod
+
+COPY --from=development /src/app/dist ./dist
+
+CMD ["node", "dist/apps/auth/main"]

--- a/apps/auth/src/auth.controller.spec.ts
+++ b/apps/auth/src/auth.controller.spec.ts
@@ -1,0 +1,22 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+
+describe('AuthController', () => {
+  let authController: AuthController;
+
+  beforeEach(async () => {
+    const app: TestingModule = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [AuthService],
+    }).compile();
+
+    authController = app.get<AuthController>(AuthController);
+  });
+
+  describe('root', () => {
+    it('should return "Hello World!"', () => {
+      expect(authController.getHello()).toBe('Hello World!');
+    });
+  });
+});

--- a/apps/auth/src/auth.controller.ts
+++ b/apps/auth/src/auth.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { AuthService } from './auth.service';
+
+@Controller()
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Get()
+  getHello(): string {
+    return this.authService.getHello();
+  }
+}

--- a/apps/auth/src/auth.module.ts
+++ b/apps/auth/src/auth.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { UsersModule } from './users/users.module';
+import { LoggerModule } from '@app/common';
+
+@Module({
+  imports: [UsersModule, LoggerModule],
+  controllers: [AuthController],
+  providers: [AuthService],
+})
+export class AuthModule {}

--- a/apps/auth/src/auth.service.ts
+++ b/apps/auth/src/auth.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AuthService {
+  getHello(): string {
+    return 'Hello World!';
+  }
+}

--- a/apps/auth/src/main.ts
+++ b/apps/auth/src/main.ts
@@ -1,0 +1,12 @@
+import { NestFactory } from '@nestjs/core';
+import { AuthModule } from './auth.module';
+import { ValidationPipe } from '@nestjs/common';
+import { Logger } from 'nestjs-pino';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AuthModule);
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+  app.useLogger(app.get(Logger));
+  await app.listen(process.env.PORT ?? 3001);
+}
+bootstrap();

--- a/apps/auth/src/users/dto/create-user.dto.ts
+++ b/apps/auth/src/users/dto/create-user.dto.ts
@@ -1,0 +1,9 @@
+import { IsEmail, IsStrongPassword } from "class-validator";
+
+export class CreateUserDto {
+  @IsEmail()
+  email: string;
+
+  @IsStrongPassword()
+  password: string;
+}

--- a/apps/auth/src/users/models/user.schema.ts
+++ b/apps/auth/src/users/models/user.schema.ts
@@ -1,0 +1,13 @@
+import { AbstractDocument } from '@app/common';
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+
+@Schema({ versionKey: false })
+export class UserDocument extends AbstractDocument {
+  @Prop()
+  email: string;
+
+  @Prop()
+  password: string;
+}
+
+export const UserSchema = SchemaFactory.createForClass(UserDocument);

--- a/apps/auth/src/users/users.controller.spec.ts
+++ b/apps/auth/src/users/users.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UsersController } from './users.controller';
+
+describe('UsersController', () => {
+  let controller: UsersController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UsersController],
+    }).compile();
+
+    controller = module.get<UsersController>(UsersController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/auth/src/users/users.controller.ts
+++ b/apps/auth/src/users/users.controller.ts
@@ -1,0 +1,13 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { CreateUserDto } from './dto/create-user.dto';
+import { UsersService } from './users.service';
+
+@Controller('users')
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Post()
+  async createUser(@Body() createUserDto: CreateUserDto) {
+    return this.usersService.create(createUserDto);
+  }
+}

--- a/apps/auth/src/users/users.module.ts
+++ b/apps/auth/src/users/users.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { UsersController } from './users.controller';
+import { UsersService } from './users.service';
+import { DatabaseModule } from '@app/common';
+import { UserDocument, UserSchema } from './models/user.schema';
+import { UserRepository } from './users.repository';
+
+@Module({
+  imports: [
+    DatabaseModule,
+    DatabaseModule.forFeature([
+      { name: UserDocument.name, schema: UserSchema },
+    ]),
+  ],
+  controllers: [UsersController],
+  providers: [UsersService, UserRepository],
+  exports: [UsersService],
+})
+export class UsersModule {}

--- a/apps/auth/src/users/users.repository.ts
+++ b/apps/auth/src/users/users.repository.ts
@@ -1,0 +1,17 @@
+import { AbstractRepository } from '@app/common';
+import { Injectable, Logger } from '@nestjs/common';
+import { UserDocument } from './models/user.schema';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+
+@Injectable()
+export class UserRepository extends AbstractRepository<UserDocument> {
+  protected readonly logger = new Logger(UserRepository.name);
+
+  constructor(
+    @InjectModel(UserDocument.name)
+    userModel: Model<UserDocument>,
+  ) {
+    super(userModel);
+  }
+}

--- a/apps/auth/src/users/users.service.spec.ts
+++ b/apps/auth/src/users/users.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UsersService } from './users.service';
+
+describe('UsersService', () => {
+  let service: UsersService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [UsersService],
+    }).compile();
+
+    service = module.get<UsersService>(UsersService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/auth/src/users/users.service.ts
+++ b/apps/auth/src/users/users.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common';
+import { CreateUserDto } from './dto/create-user.dto';
+import { UserRepository } from './users.repository';
+
+@Injectable()
+export class UsersService {
+  constructor(private readonly usersRepository: UserRepository) {}
+
+  async create(createUserDto: CreateUserDto) {
+    return this.usersRepository.create(createUserDto);
+  }
+}

--- a/apps/auth/test/app.e2e-spec.ts
+++ b/apps/auth/test/app.e2e-spec.ts
@@ -1,0 +1,24 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AuthModule } from './../src/auth.module';
+
+describe('AuthController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AuthModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  it('/ (GET)', () => {
+    return request(app.getHttpServer())
+      .get('/')
+      .expect(200)
+      .expect('Hello World!');
+  });
+});

--- a/apps/auth/test/jest-e2e.json
+++ b/apps/auth/test/jest-e2e.json
@@ -1,0 +1,9 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": ".",
+  "testEnvironment": "node",
+  "testRegex": ".e2e-spec.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  }
+}

--- a/apps/auth/tsconfig.app.json
+++ b/apps/auth/tsconfig.app.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "declaration": false,
-    "outDir": "../../dist/apps/reservations"
+    "outDir": "../../dist/apps/auth"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]

--- a/apps/reservations/Dockerfile
+++ b/apps/reservations/Dockerfile
@@ -1,0 +1,34 @@
+FROM node:alpine AS development
+
+WORKDIR /src/app
+
+COPY package.json ./
+COPY pnpm-lock.yaml ./
+
+RUN npm i -g @nestjs/cli
+
+RUN npm install -g pnpm
+
+RUN pnpm install
+
+COPY . .
+
+RUN pnpm run build
+
+FROM node:alpine AS production
+
+ARG NODE_ENV=production
+ENV NODE_ENV=${NODE_ENV}
+
+WORKDIR /src/app
+
+COPY package.json ./
+COPY pnpm-lock.yaml ./
+
+RUN npm install -g pnpm
+
+RUN pnpm install --prod
+
+COPY --from=development /src/app/dist ./dist
+
+CMD ["node", "dist/apps/reservations/main"]

--- a/apps/reservations/src/main.ts
+++ b/apps/reservations/src/main.ts
@@ -4,9 +4,11 @@ import { ReservationsModule } from './reservations.module';
 import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
+  console.log(process.env.MONGODB_URI);
+  console.log('Hello!');
   const app = await NestFactory.create(ReservationsModule);
   app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
   app.useLogger(app.get(Logger));
-  await app.listen(process.env.port ?? 5000);
+  await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,62 @@
+version: '3.8'
+
+services:
+  mongo:
+    image: mongo
+    container_name: mongodb
+    restart: unless-stopped
+    volumes:
+      - mongo-data:/data/db
+    ports:
+      - "27017:27017"
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "quit(0)"]
+      interval: 5s
+      timeout: 3s
+      retries: 3
+      start_period: 30s
+
+  reservations:
+    build:
+      context: .
+      dockerfile: ./apps/reservations/Dockerfile
+      target: development
+    command: pnpm run start:dev reservations
+    ports:
+      - '3000:3000'
+    volumes:
+      - ./:/src/app:deleg
+      - node_modules_reservations:/src/app/node_modules
+    env_file:
+      - .env
+    environment:
+      - PORT=3000
+      - MONGODB_URI=mongodb://mongo:27017/sleepr
+    depends_on:
+      mongo:
+        condition: service_healthy
+
+  auth:
+    build:
+      context: .
+      dockerfile: ./apps/auth/Dockerfile
+      target: development
+    command: pnpm run start:dev auth
+    ports:
+      - '3001:3001'
+    volumes:
+      - ./:/src/app:deleg
+      - node_modules_auth:/src/app/node_modules
+    env_file:
+      - .env
+    environment:
+      - PORT=3001
+      - MONGODB_URI=mongodb://mongo:27017/sleepr
+    depends_on:
+      mongo:
+        condition: service_healthy
+
+volumes:
+  mongo-data:
+  node_modules_reservations:
+  node_modules_auth:

--- a/libs/common/src/database/database.module.ts
+++ b/libs/common/src/database/database.module.ts
@@ -6,9 +6,12 @@ import { ModelDefinition, MongooseModule } from '@nestjs/mongoose';
   imports: [
     MongooseModule.forRootAsync({
       imports: [ConfigModule],
-      useFactory: (configService: ConfigService) => ({
-        uri: configService.get('MONGODB_URI'),
-      }),
+      useFactory: (configService: ConfigService) => {
+        console.log(configService.get('MONGODB_URI'));
+        return {
+          uri: configService.get('MONGODB_URI'),
+        }
+      },
       inject: [ConfigService],
     }),
   ],

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -8,6 +8,15 @@
     "tsConfigPath": "apps/reservations/tsconfig.app.json"
   },
   "projects": {
+    "auth": {
+      "type": "application",
+      "root": "apps/auth",
+      "entryFile": "main",
+      "sourceRoot": "apps/auth/src",
+      "compilerOptions": {
+        "tsConfigPath": "apps/auth/tsconfig.app.json"
+      }
+    },
     "common": {
       "type": "library",
       "root": "libs/common",


### PR DESCRIPTION
I was seeing connection failures because the NestJS containers attempted to connect to `mongodb://localhost:27017/...`. Inside a Docker container `localhost` refers to *the container itself*, not the MongoDB service — so the app was trying to talk to a non-existent DB inside its own container.

This PR fixes that by:

* Changing the Mongo URI to use Docker service discovery (`MONGODB_URI=mongodb://mongo:27017/sleepr`) so the app connects to the `mongo` service.
* Moving environment values into a single `.env` and using `env_file` in `docker-compose` for consistent configuration.
* Adding a `healthcheck` to the `mongo` service and `depends_on: condition: service_healthy` for the app services so they wait until Mongo is ready.
* Introducing named volumes:

  * `mongo-data` to persist DB data across container restarts.
  * `node_modules_reservations` / `node_modules_auth` to avoid overwriting container-installed `node_modules` when bind-mounting the repo for dev.
* Keeping the dev workflow (bind-mounts and `pnpm start:dev`) but isolating `node_modules` so builds and runtime dependencies are consistent.

Why this matters: Docker containers use an internal network where services resolve by name. Using `localhost` caused the app to look locally (and fail), while using the service name (`mongo`) enables reliable inter-container communication. The healthcheck prevents race conditions where the app starts before Mongo is ready.

**Files changed**

* `docker-compose.yaml` — updated Mongo URI, added `healthcheck`, `depends_on`, named volumes, `env_file`.
* `.env` — updated to `MONGODB_URI=mongodb://mongo:27017/sleepr`.
